### PR TITLE
Allow for arbitrary species identifiers. Add Python 3 FortFlex module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@ doc/build/*
 .project
 .pydev*
 f2py_build/f90/*
-FortFlex.so
+FortFlex*.so
 .idea/*
 
 /.cache/
 .*.swp
+

--- a/reflexible/conv2netcdf4/fortflex/build_FortFlex.sh
+++ b/reflexible/conv2netcdf4/fortflex/build_FortFlex.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-rm -f FortFlex.pyf
 f2py -m FortFlex -h FortFlex.pyf FortFlex.f
 f2py -c --fcompiler=gfortran FortFlex.pyf FortFlex.f
+rm -f FortFlex.pyf
 mv *.so ..
 

--- a/reflexible/conv2netcdf4/fortflex/build_FortFlex_py3.sh
+++ b/reflexible/conv2netcdf4/fortflex/build_FortFlex_py3.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+f2py3 -m FortFlex -h FortFlex.pyf FortFlex.f
+f2py3 -c --fcompiler=gfortran FortFlex.pyf FortFlex.f
+rm -f FortFlex.pyf
+mv *.so ..
+

--- a/reflexible/conv2netcdf4/grid_read.py
+++ b/reflexible/conv2netcdf4/grid_read.py
@@ -613,7 +613,7 @@ def readgridV8(H, **kwargs):
 
     # What species to return?
     nspec_ret = OPS.nspec_ret
-    if isinstance(nspec_ret, int):
+    if isinstance(nspec_ret, (int, np.int64)):
         nspec_ret = [nspec_ret]
     assert iter(nspec_ret), "nspec_ret must be iterable."
 
@@ -622,7 +622,7 @@ def readgridV8(H, **kwargs):
     if OPS.time_ret is not None:
         get_dates = []
         time_ret = OPS.time_ret
-        if isinstance(time_ret, int) == True:
+        if isinstance(time_ret, (int, np.int64)):
             time_ret = [time_ret]
 
         if time_ret[0] < 0:
@@ -861,7 +861,7 @@ def readgridV6(H, **kwargs):
 
     # What species to return?
     nspec_ret = OPS.nspec_ret
-    if isinstance(nspec_ret, int):
+    if isinstance(nspec_ret, (int, np.int64)):
         nspec_ret = [nspec_ret]
     assert iter(nspec_ret), "nspec_ret must be iterable."
 
@@ -870,7 +870,7 @@ def readgridV6(H, **kwargs):
     if OPS.time_ret is not None:
         get_dates = []
         time_ret = OPS.time_ret
-        if isinstance(time_ret, int) == True:
+        if isinstance(time_ret, (int, np.int64)):
             time_ret = [time_ret]
 
         if time_ret[0] < 0:
@@ -1097,7 +1097,7 @@ def fill_grids(H, nspec=0, FD=None):
 
     #    assert H.direction == 'backward', "fill_backward is only valid for backward runs"
     # make sure npsec is iterable
-    if isinstance(nspec, int):
+    if isinstance(nspec, (int, np.int64)):
         species = [nspec]
     else:
         species = nspec

--- a/reflexible/conv2netcdf4/tests/test_netcdf4_structure.py
+++ b/reflexible/conv2netcdf4/tests/test_netcdf4_structure.py
@@ -179,7 +179,7 @@ class TestStructure:
     def test_species_mr(self):
         attr_names = ('units', 'long_name', 'decay', 'weightmolar',
                       'ohreact', 'kao', 'vsetaver', 'spec_ass')
-        for i in range(0, self.H.nspec):
+        for i in range(self.H.nspec):
             anspec = "%3.3d" % (i + 1)
             if self.ncid.iout in (1, 3, 5):
                 var_name = "spec" + anspec + "_mr"
@@ -194,7 +194,7 @@ class TestStructure:
     def test_species_pptv(self):
         attr_names = ('units', 'long_name', 'decay', 'weightmolar',
                       'ohreact', 'kao', 'vsetaver', 'spec_ass')
-        for i in range(0, self.H.nspec):
+        for i in range(self.H.nspec):
             anspec = "%3.3d" % (i + 1)
             if self.ncid.iout in (2, 3):
                 var_name = "spec" + anspec + "_pptv"
@@ -217,7 +217,7 @@ class TestWetDryDeps:
     def test_WDspecies(self):
         attr_names = ('units', 'weta', 'wetb', 'weta_in', 'wetb_in',
                       'wetc_in', 'wetd_in', 'dquer', 'henry')
-        for i in range(0, self.H.nspec):
+        for i in range(self.H.nspec):
             anspec = "%3.3d" % (i + 1)
             if self.dataset.wetdep:
                 var_name = "WD_spec" + anspec
@@ -232,7 +232,7 @@ class TestWetDryDeps:
     def test_DDspecies(self):
         attr_names = ('units', 'dryvel', 'reldiff', 'henry', 'f0',
                       'dquer', 'density', 'dsigma')
-        for i in range(0, self.H.nspec):
+        for i in range(self.H.nspec):
             anspec = "%3.3d" % (i + 1)
             if self.dataset.drydep:
                 var_name = "DD_spec" + anspec

--- a/reflexible/flexpart.py
+++ b/reflexible/flexpart.py
@@ -48,7 +48,7 @@ class Flexpart(object):
         # Other config files
         self.Command = read_conffiles("COMMAND", self.fp_options, None)
         self.Releases = read_conffiles("RELEASES", self.fp_options, None)
-        self.Species = read_species(self.fp_options, self.Header.nspec)
+        self.Species = read_species(self.fp_options, self.Header.nspec, spec_ids=self.Releases['spec_ids'])
 
     def __str__(self):
         return "Flexpart('%s', nested=%s)" % (self.pathnames, self.nested)

--- a/reflexible/scripts/create_ncfile.py
+++ b/reflexible/scripts/create_ncfile.py
@@ -41,7 +41,7 @@ COMPLEVEL = 9
 MIN_SIZE = False
 
 
-def read_species(options_dir, nspec):
+def read_species(options_dir, nspec, spec_ids=None):
     """Read metadata from SPECIES dir and return it as a dict.
 
     TODO: maybe the current version is specific of FLEXPART 9.
@@ -72,7 +72,9 @@ def read_species(options_dir, nspec):
         }
 
     dspec = defaultdict(list)
-    for spec in range(1, nspec+1):
+    if spec_ids is None:
+        spec_ids = range(1, nspec+1)
+    for spec in spec_ids:
         path = os.path.join(species_dir, "SPECIES_%03d" % spec)
         with open(path) as fspec:
             for line in fspec:
@@ -387,7 +389,7 @@ def write_header(H, ncid, wetdep, drydep, write_releases, species):
 
     chunksizes = (H.numxgrid, H.numygrid, H.numzgrid, 1, 1, 1)[::-1]
     dep_chunksizes = (H.numxgrid, H.numygrid, 1, 1, 1)[::-1]
-    for i in range(0, H.nspec):
+    for i in range(H.nspec):
         anspec = "%3.3d" % (i + 1)
         # iout: 1 conc. output (ng/m3), 2 mixing ratio (pptv), 3 both,
         # 4 plume traject, 5=1+4
@@ -608,7 +610,7 @@ def create_ncfile(pathnames, nested, wetdep=False, drydep=False,
     if options_dir:
         command = read_conffiles("COMMAND", options_dir, command_path)
         releases = read_conffiles("RELEASES", options_dir, releases_path)
-        species = read_species(options_dir, H.nspec)
+        species = read_species(options_dir, H.nspec, spec_ids=releases['spec_ids'])
 
     if outfile:
         # outfile has priority over previous flags

--- a/reflexible/tests/test_flexpart.py
+++ b/reflexible/tests/test_flexpart.py
@@ -35,15 +35,15 @@ class TestHeader:
     def test_releases(self):
         # Only test a few FP runs here
         if self.dataset.fp_name == 'Fwd1_V10.1':
-            releases = self.fprun.Releases[:]
+            releases = self.fprun.Releases['releases']
             assert len(releases) == 1
             assert tuple(releases[0]) == (
                 20050501, 0, 20050502, 0, 10.5, 11.0, 59.75, 60.25, 0.0,
                 100.0, 1, 1.0, 10000, b'OsloRelease')
         elif self.dataset.fp_name == 'Fwd1_V9.02':
-            releases = self.fprun.Releases
+            releases = self.fprun.Releases['release_point_names']
             assert len(releases) == 1
-            assert releases['release_point_names'][0] == b'RELEASE_TEST1'
+            assert releases[0] == b'RELEASE_TEST1'
 
     def test_command(self):
         command = self.fprun.Command
@@ -73,4 +73,56 @@ class TestHeader:
 
     def test_species(self):
         species = self.fprun.Species
-        assert species['dryvel'] == [-9.99]
+        if self.dataset.fp_name == 'Fwd1_V10.1':
+            # species id = 15
+            assert species == {
+                'decay': [691200.0],
+                # TODO: Search string in reflexible.scripts.create_ncfile.read_species
+                # needs to be updated to handle below/in-cloud scavenging in V10
+                #'weta': [1.0E-04],
+                #'wetb': [0.80],
+                'reldiff': [-9.9],
+                'henry': [-9.9],
+                'f0': [-9.9],
+                'dquer': [6.0E-7],
+                'dsigma': [3.0E-1],
+                'dryvel': [-9.99],
+                'weightmolar': [-9.99],
+                'ohreact': [-9.9E-09],
+                'spec_ass': [-9],
+                'kao': [-99.99]
+            }
+        elif self.dataset.fp_name == 'Fwd1_V9.02':
+            # species id = 1
+            assert species == {
+                'decay': [-999.9],
+                'weta': [-9.9E-09],
+                'wetb': [-9.9E-09],
+                'reldiff': [-9.9],
+                'henry': [-9.9],
+                'f0': [-9.9],
+                'dquer': [-9.9],
+                'dsigma': [-9.9],
+                'dryvel': [-9.99],
+                'weightmolar': [350.00],
+                'ohreact': [-9.9E-09],
+                'spec_ass': [-9],
+                'kao': [-99.99]
+            }
+        elif self.dataset.fp_name == 'Fwd2_V9.02':
+            # species id = 12
+            assert species == {
+                'decay': [-999.9],
+                'weta': [5.0E-06],
+                'wetb': [0.62],
+                'reldiff': [-9.9],
+                'henry': [1.0E-09],
+                'f0': [1.0E-09],
+                'dquer': [4.0E-7],
+                'dsigma': [3.0E-1],
+                'dryvel': [-9.99],
+                'weightmolar': [-9.99],
+                'ohreact': [-9.9E-09],
+                'spec_ass': [-9],
+                'kao': [-99.99]
+            }


### PR DESCRIPTION
* .gitignore: Ignore .cache from Python tests and FortFlex extension modules
* reflexible/conv2netcdf4/flexpart_read.py: Extract the species identifiers metadata from the RELEASES file
* reflexible/conv2netcdf4/fortflex/build_FortFlex.sh: Remove signature file after invoking f2py rather than before so it doesn't accidentally get checked into repo
* reflexible/conv2netcdf4/fortflex/build_FortFlex_py3.sh: Add Python 3 FortFlex module builder
* reflexible/conv2netcdf4/grid_read.py: Accept type np.int64 in instance comparisons for nspec_ret, time_ret and nspec
* reflexible/conv2netcdf4/tests/test_netcdf4_structure.py: Make the range call a little more succinct
* reflexible/flexpart.py: Use the species identifiers in reading the species files
* reflexible/scripts/create_ncfile.py: Use the species identifiers in reading the species files
* reflexible/tests/test_flexpart.py: Update release tests to account for new dictionary structure separating release data and metadata (i.e. species IDs)
* reflexible/tests/test_flexpart.py: Update species tests to more thoroughly test species parameters