### PR TITLE
fix typo in installation instructions

### DIFF
--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -53,7 +53,7 @@ the git repository::
 
     $ git clone https://github.com/spectraphilic/reflexible.git
 
-Install the requirements:
+Install the requirements::
 
     $ conda install --file requirements.txt -c conda-forge
 


### PR DESCRIPTION
the `conda install` command wasn't rendered correctly.  That was bad, because copy-paste of the command led to an error (the `--` was rendered as unicode em-dash by rtd)